### PR TITLE
fix(web): 앱에서 의도한 색상과 다른 색상이 웹에서 보여지던 문제 해결

### DIFF
--- a/server/src/main/resources/static/test.html
+++ b/server/src/main/resources/static/test.html
@@ -70,8 +70,10 @@
 
             if (command.style) {
                 const style = command.style;
-                if (style.backgroundColor) el.style.backgroundColor = style.backgroundColor;
-                if (style.color) el.style.color = style.color;
+
+                //'AARRGGBB'를 'rgba()'로 변환
+                if (style.backgroundColor) el.style.backgroundColor = aarrggbbToRgba(style.backgroundColor);
+                if (style.fontColor) el.style.color = aarrggbbToRgba(style.fontColor);
                 if (style.fontSize) el.style.fontSize = style.fontSize + 'px';
                 if (style.fontWeight) el.style.fontWeight = style.fontWeight;
                 if (style.fontFamily) el.style.fontFamily = style.fontFamily;


### PR DESCRIPTION
## #️⃣ 요약

앱에서 의도한 색상과 다른 색상이 웹에서 보여지던 문제 해결

## #️⃣ 연관된 이슈



## #️⃣ 작업 내용

1. aarrggbb 컬러 포맷 에서 rgba로 변환해주는 함수 구현
2. 글자색, 컴포넌트 배경색을 해당 rgba변환 함수를 호출하여 정제하는 코드 추가  
## #️⃣ 테스트 결과

<img width="986" height="542" alt="image" src="https://github.com/user-attachments/assets/815a21de-114e-4fd1-a68d-9f68e392cd3d" />

## #️⃣ 변경 사항 체크리스트

- [x] 코드 컨벤션에 따라 코드를 작성했나요?
- [x] 본 PR에서 발생할 수 있는 모든 의존성 문제가 해결되었나요?