### PR TITLE
fix(web): 웹 컴포넌트의 컨텐츠를 중앙 정렬되도록 수정

### DIFF
--- a/server/src/main/resources/static/test.html
+++ b/server/src/main/resources/static/test.html
@@ -66,7 +66,10 @@
             el.style.left = (command.offsetX || 10) + 'px';
             el.style.width = (command.width || 200) + 'px';
             el.style.height = (command.height || 150) + 'px';
-            // el.style.border = '1px solid gray';
+
+            el.style.display = 'flex';
+            el.style.alignItems = 'center'; // 수직 중앙
+            el.style.justifyContent = 'center'; // 수평 중앙
 
             if (command.text) {
                 el.innerText = command.text;
@@ -86,7 +89,7 @@
                     el.style.borderColor = aarrggbbToRgba(style.borderColor);
                     el.style.borderWidth = '1px';
                     el.style.borderStyle = 'solid';
-        }
+                }
             }
         }
 


### PR DESCRIPTION
## #️⃣ 요약

웹 컴포넌트의 컨텐츠를 중앙 정렬되도록 수정

## #️⃣ 연관된 이슈

#34 

## #️⃣ 작업 내용

1. 중앙 정렬을 위해 p, button 태그의 내용의 margin을 0으로 설정하는 CSS 추가
2. 웹 코드에 CSS Flexbox 속성(display, alignItems, justifyContent)을 추가하여 앱과 동일하게 콘텐츠가 수직/수평 중앙에 위치하도록 수정

## #️⃣ 테스트 결과

> 코드 변경에 대해 테스트를 수행한 결과를 요약해주세요. 예: 모든 테스트 통과 여부, 새로 작성한 테스트 케이스 등

## #️⃣ 변경 사항 체크리스트

- [x] 코드 컨벤션에 따라 코드를 작성했나요?
- [x] 본 PR에서 발생할 수 있는 모든 의존성 문제가 해결되었나요?