### PR TITLE
fix(app):  커스텀 CSS 입력 칸에서 값을 지울 때, 갑자기 값이 커지는 버그 해결

### DIFF
--- a/app/src/main/java/com/example/kotlin_openmission_8/components/CreateMenu.kt
+++ b/app/src/main/java/com/example/kotlin_openmission_8/components/CreateMenu.kt
@@ -237,7 +237,7 @@ fun CreateMenu(
                     borderRadius = it.toFloatOrNull() ?: borderRadius
                 }
             },
-            label = { Text("Border Radius (px)") },
+            label = { Text("Border Radius") },
             keyboardOptions = KeyboardOptions(keyboardType = KeyboardType.Number)
         )
 


### PR DESCRIPTION
## #️⃣ 요약

커스텀 CSS 입력 칸에서 값을 지울 때, 갑자기 값이 커지는 버그 해결

## #️⃣ 연관된 이슈

#40 

## #️⃣ 작업 내용

1. CSS 입력 필드 UI 에서 소수점을 지울 수 없도록 수정


## #️⃣ 변경 사항 체크리스트

- [x] 코드 컨벤션에 따라 코드를 작성했나요?
- [x] 본 PR에서 발생할 수 있는 모든 의존성 문제가 해결되었나요?
