### PR TITLE
feat(app): 컴포넌트를 선택했을 때 바운딩 박스가 나타나는 기능 구현

### DIFF
--- a/app/src/main/java/com/example/kotlin_openmission_8/components/ComponentBox.kt
+++ b/app/src/main/java/com/example/kotlin_openmission_8/components/ComponentBox.kt
@@ -213,8 +213,8 @@ fun ComponentBox(
 @Composable
 private fun BoxScope.Handle(
     alignment: Alignment,
-    size: Dp = 10.dp,
-    color: Color = Color.Blue
+    size: Dp = 8.dp,
+    color: Color = Color.Green
 ) {
     val bias = alignment as? BiasAlignment ?: return
     Box(


### PR DESCRIPTION
## #️⃣ 요약

컴포넌트를 선택했을 때 바운딩 박스가 나타나는 기능 구현

## #️⃣ 작업 내용

1.  ComponentBox에 컴포넌트의 선택 여부를 나타내는 상태 정의
2. 지정된 위치에 원(handle)을 그리는 함수 구현
3. 컴포넌트가 선택된 상태라면 8방향에 원을 그리는 기능 구현

## #️⃣ 변경 사항 체크리스트

- [x] 코드 컨벤션에 따라 코드를 작성했나요?
- [x]본 PR에서 발생할 수 있는 모든 의존성 문제가 해결되었나요?

## #️⃣ 스크린샷 

<img width="959" height="434" alt="image" src="https://github.com/user-attachments/assets/78bc5504-8661-4579-9411-f62f12a107c3" />
