### PR TITLE
fix(app): 캔버스 초기 진입 시 선택하지 않은 컴포넌트 박스에 바운딩 박스가 적용되는 문제 해결

### DIFF
--- a/app/src/main/java/com/example/kotlin_openmission_8/model/Components.kt
+++ b/app/src/main/java/com/example/kotlin_openmission_8/model/Components.kt
@@ -178,10 +178,6 @@ class Components(private val client: HttpClient): ViewModel() {
                                     val allComponents = Json.decodeFromString<List<Component>>(message)
                                     _components.value = allComponents
                                     println("📦 초기 데이터 로드 완료: ${allComponents.size}개")
-
-                                    if (allComponents.isNotEmpty()) {
-                                        _component.value = allComponents.first()
-                                    }
                                 } else {
                                     // 2. 단일 명령 수신
                                     val command = Json.decodeFromString<Component>(message)


### PR DESCRIPTION

## #️⃣ 요약

캔버스 초기 진입 시 선택하지 않은 컴포넌트 박스에 바운딩 박스가 적용되는 문제 해결

## #️⃣ 연관된 이슈

#43 

## #️⃣ 작업 내용

1.  Components 클래스에서 서버에서 초기 데이터 목록을 받을 때 첫 번째 컴포넌트를 선택하는 코드를 삭제

## #️⃣ 변경 사항 체크리스트

- [x] 코드 컨벤션에 따라 코드를 작성했나요?
- [x] 본 PR에서 발생할 수 있는 모든 의존성 문제가 해결되었나요?
